### PR TITLE
Migrate to trunk-based development (main branch)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,7 @@ name: tests
 on:
   push:
     branches:
-      - master
-      - develop
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Changes

- Update CI workflow triggers: replace `develop`/`master` branch references with `main`
- Default branch already changed to `main` on GitHub

## Context

Migrating from Git Flow (develop/main) to trunk-based development with `main` as the sole branch.

After merge, the `develop` branch will be deleted.